### PR TITLE
Upgrade KebabPos to 2.3.1 and SLF4J migration

### DIFF
--- a/kebabpos/build.gradle
+++ b/kebabpos/build.gradle
@@ -16,6 +16,7 @@ run {
 }
 
 dependencies {
-    compile 'com.assemblypayments:spi-client-java:2.3.0'
+    compile 'com.assemblypayments:spi-client-java:2.3.1'
+    compile 'org.apache.logging.log4j:log4j-slf4j-impl:2.10.0'
     compile project(':utils')
 }


### PR DESCRIPTION
Since the new SPI client migrated from Log4j to SLF4J, any client choosing to use Log4j needs to include the `log4j-slf4j-impl` library.